### PR TITLE
Select related extensions

### DIFF
--- a/docs/MANUAL.txt
+++ b/docs/MANUAL.txt
@@ -331,6 +331,12 @@ the following command from the root of your project::
 
     python manage.py syncdb
 
+To limit the numbers of SQL queries to the database django-treemenus can automaticly select
+the related extensions when the menu items are fetched. For this to be possible you have to
+add the relation name to TREEMENUS_EXTENSION_RELATED_NAME in your settings.py:
+
+    TREEMENUS_EXTENSION_RELATED_NAME = 'extension'
+
 Now, you need to specify a form to let you edit those extra attributes from the admin interface.
 In your project's ``admin.py`` or your extension menu app's ``admin.py``, add the following::
 

--- a/treemenus/models.py
+++ b/treemenus/models.py
@@ -96,7 +96,11 @@ class MenuItem(models.Model):
         return self.siblings().count() > 0
     
     def children(self):
-        _children = MenuItem.objects.filter(parent=self).order_by('rank',)
+        try:
+            _children = MenuItem.objects.select_related(settings
+            .TREEMENUS_EXTENSION_RELATED_NAME).filter(parent=self).order_by('rank',)
+        except AttributeError:
+            _children = MenuItem.objects.filter(parent=self).order_by('rank',)
         for child in _children:
             child.parent = self # Hack to avoid unnecessary DB queries further down the track.
         return _children


### PR DESCRIPTION
Added possibility to select related extensions in models.MenuItem.children(). Requires new setting TREEMENUS_EXTENSION_RELATED_NAME set to the name of the relation.

This will reduce the number of SQL queries needed when using menu extensions.

Docs are updated accordingly. 
