### PR TITLE
Update setup.py to include static image assets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,9 @@ setup(
     packages=find_packages(),
     package_data={
         'treemenus': [
+            'static/img/treemenus/*.gif',
             'templates/admin/treemenus/menu/*.html',
-            'templates/admin/treemenus/menuitem/*.html'
+            'templates/admin/treemenus/menuitem/*.html',
         ]
     },
     zip_safe=False,


### PR DESCRIPTION
The images in `static` were omitted when installing. I've updated `setup.py` to include them.
