### PR TITLE
Fix reverse_named_url broken in Django 1.5

### DIFF
--- a/treemenus/templatetags/tree_menu_tags.py
+++ b/treemenus/templatetags/tree_menu_tags.py
@@ -48,7 +48,7 @@ class ReverseNamedURLNode(Node):
         from django.template import TOKEN_BLOCK, Token
 
         resolved_named_url = self.named_url.resolve(context)
-        contents = u'url ' + resolved_named_url
+        contents = u'url "%s"' % (resolved_named_url,)
 
         urlNode = url(self.parser, Token(token_type=TOKEN_BLOCK, contents=contents))
         return urlNode.render(context)

--- a/treemenus/templatetags/tree_menu_tags.py
+++ b/treemenus/templatetags/tree_menu_tags.py
@@ -48,7 +48,10 @@ class ReverseNamedURLNode(Node):
         from django.template import TOKEN_BLOCK, Token
 
         resolved_named_url = self.named_url.resolve(context)
-        contents = u'url "%s"' % (resolved_named_url,)
+        if django.VERSION >= (1, 3):
+            contents = u'url "%s"' % (resolved_named_url,)
+        else:
+            contents = u'url %s' % (resolved_named_url,)
 
         urlNode = url(self.parser, Token(token_type=TOKEN_BLOCK, contents=contents))
         return urlNode.render(context)


### PR DESCRIPTION
Fix error on Django 1.5 because of deprecated template tag syntax since Django 1.3.
