### PR TITLE
Avoid importing from deprecated django.conf.urls.defaults

### DIFF
--- a/treemenus/admin.py
+++ b/treemenus/admin.py
@@ -1,7 +1,10 @@
 import re
 
 import django
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except ImportError:  # Django < 1.4
+    from django.conf.urls.defaults import patterns, url
 from django.contrib import admin
 from django.contrib.admin.util import unquote
 from django.core.exceptions import PermissionDenied

--- a/treemenus/tests/urls.py
+++ b/treemenus/tests/urls.py
@@ -1,5 +1,8 @@
 import django
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django < 1.4
+    from django.conf.urls.defaults import *
 from django.contrib import admin
 
 admin.autodiscover()


### PR DESCRIPTION
Import from django.conf.urls on Django >= 1.4 and fall back to
django.conf.urls.defaults for older versions
