### PR TITLE
reverse_named_url fails on Django 1.5 if using url arguments

### DIFF
--- a/treemenus/templatetags/tree_menu_tags.py
+++ b/treemenus/templatetags/tree_menu_tags.py
@@ -49,10 +49,12 @@ class ReverseNamedURLNode(Node):
 
         resolved_named_url = self.named_url.resolve(context)
         if django.VERSION >= (1, 3):
-            contents = u'url "%s"' % resolved_named_url
+            tokens = resolved_named_url.split(' ')
+            base = tokens[0]
+            args = tokens[1:]
+            contents = u'url "{0}" {1}'.format(base, ' '.join(args))
         else:
-            contents = u'url %s' % resolved_named_url
-
+            contents = u'url {0}'.format(resolved_named_url)
         urlNode = url(self.parser, Token(token_type=TOKEN_BLOCK, contents=contents))
         return urlNode.render(context)
 


### PR DESCRIPTION
While migrating an app to Django 1.5 one of my menus handled by treemenus started to fail, it was looking for an url named this way:

"my_awesome_url its_awesome_argument"

All as a single url, this commit fixes that, but i owe you a test case.
