### PR TITLE
Resolve issue with importing TOKEN_BLOCK depending on django version

### DIFF
--- a/treemenus/templatetags/tree_menu_tags.py
+++ b/treemenus/templatetags/tree_menu_tags.py
@@ -60,7 +60,10 @@ class ReverseNamedURLNode(Node):
         self.parser = parser
 
     def render(self, context):
-        from django.template import TOKEN_BLOCK, Token
+        if django.VERSION >= (1, 8):
+            from django.template.base import TOKEN_BLOCK, Token
+        else:
+            from django.template import TOKEN_BLOCK, Token
 
         resolved_named_url = self.named_url.resolve(context)
         if django.VERSION >= (1, 3):


### PR DESCRIPTION
Since django 1.8 django.template.**init** module no longer imports
TOKEN_BLOCK constanct.
https://github.com/django/django/blob/1.8/django/template/__init__.py

This is patch for issue #39 
